### PR TITLE
append archived files to return lis

### DIFF
--- a/vacuum/cleaner.py
+++ b/vacuum/cleaner.py
@@ -32,8 +32,8 @@ class VacuumCleaner(object):
                                                           rule_id))
             filelist = flister(**options)
             success_files, success_dirs, errors = operation(filelist, **options)
-            self.logger.info('%s of %s complete: %d files and %d directories deleted' %\
-                (operation.__name__.title(),rule_id,len(success_files),len(success_dirs)))
+            self.logger.info('%s of %s complete: %d files and %d directories %sd' %\
+                (operation.__name__.title(),rule_id,len(success_files),len(success_dirs),operation.__name__))
             if errors:
                 self.logger.warning('Could not %s some files, please check below...' % \
                                                             operation.__name__\

--- a/vacuum/utils.py
+++ b/vacuum/utils.py
@@ -195,6 +195,7 @@ def archive(filelist, destination, root_depth=0, raise_errors=False, **kwargs):
             assert isdir(final_destination)
             if isfile(filepath) or islink(filepath):
                 shutil.copy2(filepath, final_destination)
+                success_files.append(filepath)
         except Exception as exc:
             errors[filepath] = exc
     message = 'Some files (%d) could not be archived' % len(errors)        


### PR DESCRIPTION
append files to empty list. It was previously always returning empty so we could not see if archived worked from the logs.